### PR TITLE
Fix bug in DElement.compareTo

### DIFF
--- a/src/main/java/dbf0/document/types/DElement.java
+++ b/src/main/java/dbf0/document/types/DElement.java
@@ -23,7 +23,7 @@ public abstract class DElement implements Comparable<DElement> {
     var thisType = getType();
     var thatType = o.getType();
     if (thisType != thatType) {
-      return Integer.compare(thatType.getTypeCode(), thatType.getTypeCode());
+      return Integer.compare(thisType.getTypeCode(), thatType.getTypeCode());
     }
     return compareToSameType(o);
   }

--- a/src/test/java/dbf0/document/DElementTest.java
+++ b/src/test/java/dbf0/document/DElementTest.java
@@ -1,0 +1,32 @@
+package dbf0.document;
+
+import com.codepoetics.protonpack.StreamUtils;
+import dbf0.document.types.*;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DElementTest {
+
+  private static final List<DElement> EXAMPLE_ELEMENTS = List.of(
+      DNull.getInstance(),
+      DBool.getTrue(),
+      DInt.of(7),
+      DDecimal.of(new BigDecimal("3.14")),
+      DString.of("string"),
+      DArray.of(),
+      DMap.of()
+  );
+
+  @Test public void testCompareElements() {
+    StreamUtils.zipWithIndex(EXAMPLE_ELEMENTS.stream()).forEach(indexA -> {
+      var a = indexA.getValue();
+      EXAMPLE_ELEMENTS.stream().skip(indexA.getIndex()).forEach(b ->
+          assertThat(a.compareTo(b)).isEqualTo(a == b ? 0 :
+              Integer.compare(a.getType().getTypeCode(), b.getType().getTypeCode())));
+    });
+  }
+}


### PR DESCRIPTION
Previously, was incorrectly not using both element types but instead just using one of the element types.